### PR TITLE
Resolve tibble input

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ License: Apache License (>= 2.0)
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 URL: https://github.com/tyluRp/hierplane
 BugReports: https://github.com/tyluRp/hierplane/issues
 Imports: 

--- a/R/build_tree.R
+++ b/R/build_tree.R
@@ -24,7 +24,7 @@ build_nodes <- function(x, root, title, settings) {
 
   r <- list()
 
-  cur_tib <- x[x[, settings$child_id] == root,]
+  cur_tib <- x[x[[settings$child_id]] == root, ]
 
   r$nodeType <- cur_tib[[settings$node_type]]
   r$word <- cur_tib[[settings$child]]
@@ -35,7 +35,7 @@ build_nodes <- function(x, root, title, settings) {
     r$spans <- list(pull_word_span(title, cur_tib[[settings$child_id]]))
   }
 
-  children <- x[x[, settings$parent_id] == root, 2]
+  children <- x[x[[settings$parent_id]] == root, ][[settings$child_id]]
 
   if (is.factor(children))
     children <- as.character(children)

--- a/R/utils.R
+++ b/R/utils.R
@@ -40,7 +40,7 @@ tree <- function(title, root, children, settings) {
 
 parse_root <- function(x, settings) {
   list(
-    id = x[x[[settings$link]] %in% settings$root_tag, settings$child_id],
+    id = x[x[[settings$link]] %in% settings$root_tag, ][[settings$child_id]],
     dat = x[x[[settings$link]] %in% settings$root_tag, ]
   )
 }


### PR DESCRIPTION
hierplane now works with tibbles!

```
library(hierplane)
a <- dplyr::tribble(
  ~parent_id,  ~child_id,  ~child,     ~node_type, ~link,      ~height,  ~age,
  "Bob",       "Bob",      "Bob",      "gen1",     "ROOT",     "100 cm", "60 yo",
  "Bob",       "Angelica", "Angelica", "gen2",     "daughter", "100 cm", "30 yo",
  "Bob",       "Eliza",    "Eliza",    "gen2",     "daughter", "90 cm",  "25 yo",
  "Bob",       "Peggy",    "Peggy",    "gen2",     "daughter", "50 cm",  "10 yo",
  "Angelica",  "John",     "John",     "gen3",     "son",      "10 cm",  "0.5 yo",
  "Bob",       "Jess",     "Jess",     "ext",      "cousin",   "70 cm",  "150 yo"
)

hierplane(a, title = "Family Tree",
          settings = hierplane_settings(attributes = c("height", "age")))
hierplane(as.data.frame(a), title = "Family Tree",
          settings = hierplane_settings(attributes = c("height", "age")))
```