### PR TITLE
Allow root-only input

### DIFF
--- a/R/build_tree.R
+++ b/R/build_tree.R
@@ -8,7 +8,7 @@ build_tree <- function(x, title = NULL, settings = NULL) {
   children <- build_nodes(parse_children(x, title, root$id, settings),
                           root = root$id,
                           title = title,
-                          settings = settings)
+                          settings = settings)$children
 
   jsonlite::toJSON(
     x = tree(title, root, children, settings),
@@ -18,6 +18,8 @@ build_tree <- function(x, title = NULL, settings = NULL) {
 }
 
 build_nodes <- function(x, root, title, settings) {
+
+  if (nrow(x) == 0 | is.null(x)) return(NULL)
 
   if (is.factor(root))
     root <- as.character(root)

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,9 +17,12 @@ tree <- function(title, root, children, settings) {
       nodeType = root$dat[[settings$node_type]],
       word = root$dat[[settings$child]],
       attributes = pull_attr(root$dat, settings$attributes),
-      spans = spans,
-      children = children$children)
+      spans = spans)
   )
+
+  if (!is.null(children)) {
+    tree$root$children <- children
+  }
 
   if (!is.null(settings$node_type_to_style)) {
     tree$nodeTypeToStyle <- settings$node_type_to_style


### PR DESCRIPTION
Closes #19 

```
library(hierplane)

df <- structure(
  list(
    parent_id = c("Bob", "Bob", "Bob", "Bob", "Angelica", "Bob"),
    child_id = c("Bob", "Angelica", "Eliza", "Peggy", "John", "Jess"),
    child = c("Bob", "Angelica", "Eliza", "Peggy", "John", "Jess"),
    node_type = c("gen1", "gen2", "gen2", "gen2", "gen3", "ext"),
    link = c("ROOT", "daughter", "daughter", "daughter", "son", "cousin"),
    height = c("100 cm", "100 cm", "90 cm", "50 cm", "10 cm", "70 cm"),
    age = c("60 yo", "30 yo", "25 yo", "10 yo", "0.5 yo", "150 yo")
  ),
  row.names = c(NA, -6L),
  class = c("data.frame")
)

df_dataframe <- hp_dataframe(
  .data = df[df$link == "ROOT", ],
  title = "Family",
  settings = hierplane_settings(
    attributes = c("height", "age")
  )
)

hierplane(df_dataframe)

df_spacyr <- hp_spacyr("Bob")

hierplane(df_spacyr, theme = "dark")
```